### PR TITLE
代码结构重构

### DIFF
--- a/app/scripts/config.router.js
+++ b/app/scripts/config.router.js
@@ -342,11 +342,13 @@ angular.module('nevermore')
             abstract: true,
             url: '^/app/experiment/resource',
             templateUrl: 'tpl/app/admin/experiment-index.html',
+            controller: 'ExperimentIndexCtrl',
             resolve: {
               controller: ["$ocLazyLoad", function($ocLazyLoad){
                 return $ocLazyLoad.load([
                   "scripts/services/general-service.js",
                   "scripts/services/toaster-tool.js",
+                  "scripts/controllers/app/admin/experiment-index.js",
                   "ngDialog",
                 ])
               }]

--- a/app/scripts/controllers/app/admin/experiment-course.js
+++ b/app/scripts/controllers/app/admin/experiment-course.js
@@ -1,71 +1,48 @@
 'use strict'
 
-app.controller("ExperimentCourseCtrl", ['$scope', 'Course', 'ngDialog',
-				'generalService', 'ToasterTool',
-function($scope, Course, ngDialog, generalService, ToasterTool){
-	var DEFAULT_ACCOUNTS = {
-		"data": [],
-		"totalPageNum": 0,
-		"curPageNum": 1,
-		"totalItemNum": 0,
-	}
-
-	$scope.resources = angular.copy(DEFAULT_ACCOUNTS)
-
+app.controller("ExperimentCourseCtrl", ['$scope', 'Course', 'ToasterTool',
+function($scope, Course, ToasterTool){
+	$scope.resources = angular.copy($scope.DEFAULT_RESOURCE_TEMPLATE)
 	$scope.modifyResource = modifyResource
 	$scope.addResource = addResource
 
-	loadResources()
+	$scope.loadResources(Course).then(loadSuccess, loadFail)
 
+	function loadSuccess(data){
+		angular.copy(data, $scope.resources)
+	}
 
-	function loadResources(){
-		Course.all().get(function(data){
-			angular.copy(data, $scope.resources)
-		}, function(error){
-			errorHandler(error)
-		})
+	function loadFail(error){
+		$scope.errorHandler(error)
 	}
 
 	function modifyResource(resource){
-		var accountDialog = ngDialog.open({
-			"template": "tpl/app/admin/modal/modify-experiment-course.html",
-			"controller": "ModifyExperimentCourseCtrl",
-			"closeByDocument": true,
-			"closeByEscape": true,
-			"resolve": {
-				"data": function(){
-					return resource
-				},
-			},
-		})
-		accountDialog.closePromise.then(function(data){
-			var DELETE_ACTION = "delete"
-			var MODIFY_ACTION = "modify"
-			if(data.value === DELETE_ACTION){
-				loadResources()
-				ToasterTool.success("编辑实验课程", "删除实验课程成功！")
-			}else if(data.value === MODIFY_ACTION){
-				ToasterTool.success("编辑实验课程", "编辑实验课程成功！")
-			}
-		})
+		var templateUrl = "tpl/app/admin/modal/modify-experiment-course.html"
+		var controller = "ModifyExperimentCourseCtrl"
+		var modifyDialog = new $scope.ModifyDialog()
+		modifyDialog.setCloseListener(onModify, onDelete)
+		modifyDialog.open(resource, templateUrl, controller)
+	}
+
+	function onModify(){
+		ToasterTool.success("编辑实验课程", "编辑实验课程成功！")
+	}
+
+	function onDelete(){
+		$scope.loadResources(Course).then(loadSuccess, loadFail)
+		ToasterTool.success("删除实验课程", "删除实验课程成功！")
 	}
 
 	function addResource(){
-		var resourceDialog = ngDialog.open({
-			"template": "tpl/app/admin/modal/add-experiment-course.html",
-			"controller": "AddExperimentCourseCtrl",
-			"closeByDocument": true,
-			"closeByEscape": true,
-		})
-		resourceDialog.closePromise.then(function(data){
-			if(!!data.value.resource){
-				loadResources()
-				ToasterTool.success("添加实验课程", "添加实验课程成功！")
-			}
-		})
+		var templateUrl = "tpl/app/admin/modal/add-experiment-course.html"
+		var controller = "AddExperimentCourseCtrl"
+		var addDialog = new $scope.AddDialog()
+		addDialog.setCloseListener(onAdd)
+		addDialog.open(templateUrl, controller)
 	}
 
-	function errorHandler(error){
-		console.log(error)
+	function onAdd(){
+		$scope.loadResources(Course).then(loadSuccess, loadFail)
+		ToasterTool.success("添加实验课程", "添加实验课程成功！")
 	}
 }])

--- a/app/scripts/controllers/app/admin/experiment-index.js
+++ b/app/scripts/controllers/app/admin/experiment-index.js
@@ -1,0 +1,129 @@
+app.controller("ExperimentIndexCtrl", ["$scope", "ngDialog", "ToasterTool",  
+	function($scope, ngDialog, ToasterTool){
+	$scope.DEFAULT_RESOURCE_TEMPLATE = {
+		"data": [],
+		"totalPageNum": 0,
+		"curPageNum": 1,
+		"totalItemNum": 0,
+	}
+
+	$scope.loadResources = loadResources
+
+	function loadResources(resourceFactory){
+		return resourceFactory.all().get().$promise
+	}
+
+	$scope.ModifyDialog = ModifyDialog
+	$scope.AddDialog = AddDialog
+
+	$scope.errorHandler = errorHandler
+
+	function ModifyDialog(){
+		var dialog = undefined
+		var onModify = undefined,
+			onDelete = undefined
+		var self = this
+
+		this.open = function(resource, templateUrl, controller){
+			dialog = ngDialog.open(getDialogConfig(resource, templateUrl, controller))
+			dialog.closePromise.then(processReturnValue)
+			return self
+		}
+
+		function processReturnValue(data){
+			var DELETE_ACTION = "delete"
+			var MODIFY_ACTION = "modify"
+			if(data.value === DELETE_ACTION){
+				typeof onDelete === "function" && onDelete()
+			}else if(data.value === MODIFY_ACTION){
+				typeof onModify === "function" && onModify()
+			}
+		}
+
+		this.setCloseListener = function(modify, del){
+			onModify = typeof modify === "function" ? modify : undefined
+			onDelete = typeof del === "function" ? del : undefined
+			return self
+ 		}
+	}
+
+	function AddDialog(){
+		var dialog = undefined
+		var onAdd = undefined
+		var self = this
+
+		this.open = function(templateUrl, controller){
+			dialog = ngDialog.open(getDialogConfig(templateUrl, controller))
+			dialog.closePromise.then(processReturnValue)
+			return self
+		}
+
+		function processReturnValue(data){
+			if(!!data.value.resource){
+				typeof onAdd === "function" && onAdd()
+			}
+		}
+
+		this.setCloseListener = function(add){
+			onAdd = typeof add === "function" ? add : undefined
+			return self
+ 		}
+	}
+
+	function getDialogConfig(resource, templateUrl, controller){
+		var isModifyDialogConfig = false
+		if(controller === undefined){
+			isModifyDialogConfig = false
+			controller = templateUrl
+			templateUrl = resource
+		}else{
+			isModifyDialogConfig = true
+		}
+
+		if(isModifyDialogConfig){
+			return getModifyDialogConfig(resource, templateUrl, controller)
+		}else{
+			return getAddDialogConfig(templateUrl, controller)
+		}
+	}
+
+	function getModifyDialogConfig(resource, templateUrl, controller){
+		return {
+			"template": templateUrl,
+			"controller": controller,
+			"closeByDocument": true,
+			"closeByEscape": true,
+			"resolve": {
+				"data": function(){
+					return resource
+				},
+			},
+		}
+	}
+
+	function getAddDialogConfig(templateUrl, controller){
+		return {
+			"template": templateUrl,
+			"controller": controller,
+			"closeByDocument": true,
+			"closeByEscape": true,
+		}
+	}
+
+	function errorHandler(error){
+		var errorMessage = getErrorMessage(error)
+		showErrorTip(errorMessage)
+	}
+
+	function getErrorMessage(error){
+		if(typeof error === "object"){
+			return error.errorCode || error.toString()
+		}else{
+			return error.toString()
+		}
+	}
+
+	function showErrorTip(error){
+		ToasterTool.error(error)
+	}
+}])

--- a/app/scripts/controllers/app/admin/experiment-lab.js
+++ b/app/scripts/controllers/app/admin/experiment-lab.js
@@ -1,71 +1,48 @@
 'use strict'
 
-app.controller("ExperimentLabCtrl", ['$scope', 'Lab', 'ngDialog',
-				'generalService', 'ToasterTool',
-function($scope, Lab, ngDialog, generalService, ToasterTool){
-	var DEFAULT_ACCOUNTS = {
-		"data": [],
-		"totalPageNum": 0,
-		"curPageNum": 1,
-		"totalItemNum": 0,
-	}
-
-	$scope.resources = angular.copy(DEFAULT_ACCOUNTS)
-
+app.controller("ExperimentLabCtrl", ['$scope', 'Lab', 'ToasterTool',
+function($scope, Lab, ToasterTool){
+	$scope.resources = angular.copy($scope.DEFAULT_RESOURCE_TEMPLATE)
 	$scope.modifyResource = modifyResource
 	$scope.addResource = addResource
 
-	loadResources()
+	$scope.loadResources(Lab).then(loadSuccess, loadFail)
 
+	function loadSuccess(data){
+		angular.copy(data, $scope.resources)
+	}
 
-	function loadResources(){
-		Lab.all().get(function(data){
-			angular.copy(data, $scope.resources)
-		}, function(error){
-			errorHandler(error)
-		})
+	function loadFail(error){
+		$scope.errorHandler(error)
 	}
 
 	function modifyResource(resource){
-		var accountDialog = ngDialog.open({
-			"template": "tpl/app/admin/modal/modify-experiment-lab.html",
-			"controller": "ModifyExperimentLabCtrl",
-			"closeByDocument": true,
-			"closeByEscape": true,
-			"resolve": {
-				"data": function(){
-					return resource
-				},
-			},
-		})
-		accountDialog.closePromise.then(function(data){
-			var DELETE_ACTION = "delete"
-			var MODIFY_ACTION = "modify"
-			if(data.value === DELETE_ACTION){
-				loadResources()
-				ToasterTool.success("编辑实验室", "删除实验室成功！")
-			}else if(data.value === MODIFY_ACTION){
-				ToasterTool.success("编辑实验室", "编辑实验室成功！")
-			}
-		})
+		var templateUrl = "tpl/app/admin/modal/modify-experiment-lab.html"
+		var controller = "ModifyExperimentLabCtrl"
+		var modifyDialog = new $scope.ModifyDialog()
+		modifyDialog.setCloseListener(onModify, onDelete)
+		modifyDialog.open(resource, templateUrl, controller)
+	}
+
+	function onModify(){
+		ToasterTool.success("编辑实验室", "编辑实验室成功！")
+	}
+
+	function onDelete(){
+		$scope.loadResources(Lab).then(loadSuccess, loadFail)
+		ToasterTool.success("删除实验室", "删除实验室成功！")
 	}
 
 	function addResource(){
-		var resourceDialog = ngDialog.open({
-			"template": "tpl/app/admin/modal/add-experiment-lab.html",
-			"controller": "AddExperimentLabCtrl",
-			"closeByDocument": true,
-			"closeByEscape": true,
-		})
-		resourceDialog.closePromise.then(function(data){
-			if(!!data.value.resource){
-				loadResources()
-				ToasterTool.success("添加实验室", "添加实验室成功！")
-			}
-		})
+		var templateUrl = "tpl/app/admin/modal/add-experiment-lab.html"
+		var controller = "AddExperimentLabCtrl"
+		var addDialog = new $scope.AddDialog()
+		addDialog.setCloseListener(onAdd)
+		addDialog.open(templateUrl, controller)
 	}
 
-	function errorHandler(error){
-		console.log(error)
+	function onAdd(){
+		$scope.loadResources(Lab).then(loadSuccess, loadFail)
+		ToasterTool.success("添加实验室", "添加实验室成功！")
 	}
 }])

--- a/app/scripts/controllers/app/admin/experiment.js
+++ b/app/scripts/controllers/app/admin/experiment.js
@@ -1,71 +1,48 @@
 'use strict'
 
-app.controller("ExperimentCtrl", ['$scope', 'Exp', 'ngDialog',
-				'generalService', 'ToasterTool',
-function($scope, Exp, ngDialog, generalService, ToasterTool){
-	var DEFAULT_ACCOUNTS = {
-		"data": [],
-		"totalPageNum": 0,
-		"curPageNum": 1,
-		"totalItemNum": 0,
-	}
-
-	$scope.resources = angular.copy(DEFAULT_ACCOUNTS)
-
+app.controller("ExperimentCtrl", ['$scope', 'Exp', 'ToasterTool',
+function($scope, Exp, ToasterTool){
+	$scope.resources = angular.copy($scope.DEFAULT_RESOURCE_TEMPLATE)
 	$scope.modifyResource = modifyResource
 	$scope.addResource = addResource
 
-	loadResources()
+	$scope.loadResources(Exp).then(loadSuccess, loadFail)
 
+	function loadSuccess(data){
+		angular.copy(data, $scope.resources)
+	}
 
-	function loadResources(){
-		Exp.all().get(function(data){
-			angular.copy(data, $scope.resources)
-		}, function(error){
-			errorHandler(error)
-		})
+	function loadFail(error){
+		$scope.errorHandler(error)
 	}
 
 	function modifyResource(resource){
-		var accountDialog = ngDialog.open({
-			"template": "tpl/app/admin/modal/modify-experiment.html",
-			"controller": "ModifyExperimentCtrl",
-			"closeByDocument": true,
-			"closeByEscape": true,
-			"resolve": {
-				"data": function(){
-					return resource
-				},
-			},
-		})
-		accountDialog.closePromise.then(function(data){
-			var DELETE_ACTION = "delete"
-			var MODIFY_ACTION = "modify"
-			if(data.value === DELETE_ACTION){
-				loadResources()
-				ToasterTool.success("编辑实验", "删除实验成功！")
-			}else if(data.value === MODIFY_ACTION){
-				ToasterTool.success("编辑实验", "编辑实验成功！")
-			}
-		})
+		var templateUrl = "tpl/app/admin/modal/modify-experiment.html"
+		var controller = "ModifyExperimentCtrl"
+		var modifyDialog = new $scope.ModifyDialog()
+		modifyDialog.setCloseListener(onModify, onDelete)
+		modifyDialog.open(resource, templateUrl, controller)
+	}
+
+	function onModify(){
+		ToasterTool.success("编辑实验", "编辑实验成功！")
+	}
+
+	function onDelete(){
+		$scope.loadResources(Exp).then(loadSuccess, loadFail)
+		ToasterTool.success("删除实验", "删除实验成功！")
 	}
 
 	function addResource(){
-		var resourceDialog = ngDialog.open({
-			"template": "tpl/app/admin/modal/add-experiment.html",
-			"controller": "AddExperimentCtrl",
-			"closeByDocument": true,
-			"closeByEscape": true,
-		})
-		resourceDialog.closePromise.then(function(data){
-			if(!!data.value.resource){
-				loadResources()
-				ToasterTool.success("添加实验", "添加实验成功！")
-			}
-		})
+		var templateUrl = "tpl/app/admin/modal/add-experiment.html"
+		var controller = "AddExperimentCtrl"
+		var addDialog = new $scope.AddDialog()
+		addDialog.setCloseListener(onAdd)
+		addDialog.open(templateUrl, controller)
 	}
 
-	function errorHandler(error){
-		console.log(error)
+	function onAdd(){
+		$scope.loadResources(Exp).then(loadSuccess, loadFail)
+		ToasterTool.success("添加实验", "添加实验成功！")
 	}
 }])


### PR DESCRIPTION
把几个资源页面间重复的功能模块抽到父controller中。

抽象到这个程度其实还能往下抽象，把整个流程都抽象出来，只暴露流程中的关键点出来。不同的页面只用实现关键点的函数，然后对流程进行配置就好，这样以后流程如果改变，只改一个文件即可。但是这么做代价稍大，并且这个方法自身也有弊端，单独页面的流程如果改变就会变得蛋疼，所以就做到这一步为止。（其实就是太懒，加上不确定改了会更好）

几个模态对话框也有类似的问题，但是模态对话框的功能和流程都更简短，感觉改了只会得不偿失，之后也不会再重构了。以业务为导向，后续业务复杂度上去了再说吧。（其实还是懒加不确定改了会更好）

@PYDebug @guoylyy @myhelloos 