### PR TITLE
loginCtrl重构

### DIFF
--- a/app/scripts/config.router.js
+++ b/app/scripts/config.router.js
@@ -45,7 +45,7 @@ angular.module('nevermore')
           .state('portal.login', {
             url: '^/signin',
             templateUrl: 'tpl/portal/login.html',
-            controller: 'LoginController',
+            controller: 'LoginCtrl',
             resolve: {
               controller: ['$ocLazyLoad', function($ocLazyLoad) {
                 return $ocLazyLoad.load([

--- a/app/scripts/controllers/portal/login.js
+++ b/app/scripts/controllers/portal/login.js
@@ -1,50 +1,71 @@
-'use strict';
+;(function(){
+  'use strict';
 
-app.controller('LoginController', function($scope,$rootScope, $state, $localStorage, $http,
-    $location,sessionService, tokenFactory, qService, Semester, ToasterTool) {
+  app.controller('LoginCtrl', LoginCtrl);
 
-  $scope.accountCharacter = 'TEACHER';
-  $scope.login_name = "";
-  $scope.login_password = "";
+  LoginCtrl.$inject = ["$scope", "$rootScope", "$state",
+   "sessionService", "tokenFactory", "Semester", "ToasterTool"]
 
-  //登录方法
-  $scope.login = function() {
-    $scope.message = "";
-    var _n = $scope.login_name;
-    var _p = $scope.login_password;
-    if (_n == undefined || _n == "" || _p == undefined || _p == "") {
-      $scope.errorMsg = '用户名/密码不能为空!';
-      return;
-    }
-    tokenFactory.login({
-      'X-Username': _n,
-      'X-Password': _p
-    }).post({},
-      function success(data, headers) {
+  function LoginCtrl($scope, $rootScope, $state,
+   sessionService, tokenFactory, Semester, ToasterTool){
+    $scope.accountCharacter = 'TEACHER';
+    $scope.loginName = "";
+    $scope.loginPassword = "";
+    $scope.login = login
+    $scope.forgotPassword = forgotPassword
+
+
+    function login() {
+      var name = $scope.loginName;
+      var password = $scope.loginPassword;
+      if (name === undefined || name === "" || password === undefined || password === "") {
+        ToasterTool.error('用户名/密码不能为空!');
+        return;
+      }
+      tokenFactory.login({
+        'X-Username': name,
+        'X-Password': password
+      }).post({}, loginSuccess,
+        //这里还是建议后端功能稍微强一点，能分辨出是用户名不存在还是密码错误。
+        //最近用优酷被这个问题弄的很蛋疼。。。
+        loginError);
+
+      function loginSuccess(data, headers){
         sessionService.saveToken(data.data, headers()['x-auth-token']);
-        $http.get(base_Url+'/api/semester/current',
-          {headers:{'x-auth-token':headers()['x-auth-token']}})
-        .success(function(rc){
+
+        Semester.current().get().$promise
+        .then(function(rc){
           sessionService.saveCurrSemeter(rc.data);
-          if($rootScope.currentUser.show_role == 'ADMINISTRATOR'){
-    				$state.go('app.account-admin.admin-account');
-    			}else if($rootScope.currentUser.show_role == 'TEACHER'){
-    				$state.go('app.index.teacher-reservations',{title:'APPROVED'});
-    			}else if($rootScope.currentUser.show_role == 'STUDENT'){
-    				$state.go('app.index.student-reservations',{title:'clazz'});
-    			}
+          transitStateByRole($rootScope.currentUser.show_role)
           ToasterTool.success('登录成功','欢迎回到航力云平台!');
-        }).error(function(error){
+        })
+        .catch(function(error){
           ToasterTool.error('未知错误发生!','');
         });
-      },
-      function error(data) {
+
+
+
+        function transitStateByRole(role){
+          if(role == 'ADMINISTRATOR'){
+            $state.go('app.account-admin.admin-account');
+          }else if(role == 'TEACHER'){
+            $state.go('app.index.teacher-reservations',{title:'APPROVED'});
+          }else if(role == 'STUDENT'){
+            $state.go('app.index.student-reservations',{title:'clazz'});
+          }else{
+            ToasterTool.error('未知错误发生!','');
+          }
+        }
+      }
+
+      function loginError(error){
         ToasterTool.error('登录失败','用户名或密码错误');
-      });
-  };
+      }
+    };
 
-  $scope.forgotPassword = function(){
-    ToasterTool.info('请联系管理员','联系电话: 021-65982267 力学实验中心');
-  };
+    function forgotPassword(){
+      ToasterTool.info('请联系管理员','联系电话: 021-65982267 力学实验中心');
+    };
+  }
+})()
 
-});

--- a/app/tpl/portal/login.html
+++ b/app/tpl/portal/login.html
@@ -1,31 +1,26 @@
-
 <div class="login-page" >
     <div class="banner-section banner-01">
         <div class="banner-overlay"></div>
         <div class="banner-content">
             <div class="tiger-container clearfix">
-                <!-- <div class="image-wrapper pull-left">
-                    <img src="images/portal/login/image-01.png" alt="..."/>
-                </div> -->
                 <div class="panel-wrapper pull-right">
                     <div class="panel pane-default login-panel">
                         <div class="panel-body">
                             <div class="clearfix">
                                 <h4 class="pull-left">欢迎来到同济力学云平台</h4>
-                                <!-- <a class="pull-right text-red register-link" href="#/register">立即注册&nbsp;<i class="fa fa-angle-right"></i></a> -->
                             </div>
                             <form class="login-form form-validation" name="loginForm" novalidate>
                                 <div class="input-group m-t-md">
                                     <span class="input-group-addon">
                                       <i class="fa fa-user"></i>
                                     </span>
-                                    <input type="text" class="form-control" ng-model="login_name" placeholder="请输入学号或者工号" required/>
+                                    <input type="text" class="form-control" ng-model="loginName" placeholder="请输入学号或者工号" required/>
                                 </div>
                                 <div class="input-group m-t-md">
                                     <span class="input-group-addon">
                                       <i class="fa fa-lock"></i>
                                     </span>
-                                    <input type="password" class="form-control" ng-model="login_password" placeholder="请输入密码" required/>
+                                    <input type="password" class="form-control" ng-model="loginPassword" placeholder="请输入密码" required/>
                                 </div>
                                 <div class="clearfix m-t-sm">
                                     <label class="i-checks i-checks-sm pull-left">
@@ -33,9 +28,6 @@
                                         <i></i>&nbsp;自动登录
                                     </label>
                                     <a class="pull-right forgotpwd-link" ng-click="forgotPassword()">忘记密码?</a>
-                                </div>
-                                <div class="clearfix m-t-sm">
-                                    <span class="text-danger">{{errorMsg}}</span>
                                 </div>
                                 <button class="btn btn-primary w-full m-t-sm" ng-click="login()">登录</button>
                             </form>


### PR DESCRIPTION
# 做了什么
1. 取消了两种错误提示方式。全部更改为使用ToasterTool。
2. 代码重构。使用更符合angular best practice的风格。
3. 使用$inject，其实和[dep，dep，func]的效果一样，但是看着舒服的多，最关键，在添加dep时，不会漏逗号。（我老是踩这个坑）

# 更符合angular best practice的风格
1. 把文件包在IIFE中，避免暴露全局变量。（angular居然没有做掉我也是醉了。。。）
2. 把函数调用放在最上面，实现往下埋。（这个还是蛮重要的，可读性一下就上去了）

# 还能提升的部分
1. 用户名和密码的错误提示太笼统了，具体是用户名错误还是密码错误要区分开。亲身体会，不区分的提示很蛋疼。
2. 亟需一个全局的错误处理方案。
3. 亟需一个全局的用户处理判断方案。

## 全局用户处理判断方案
管理站点会有很多用户输入，包括用户名密码这种，需要做两件事。
1. 判断用户输入是否符合规格，比方电话号码是否都是数字。
2. 做转义，防止sql注入和xss。（当然这一部分也可以纯粹靠后端来完成，现在也并不重要）

### 我觉得全局提供一个service，放置一些常用的正则会不错？常用的正则包括：
* 电话号码
* 密码
* 用户名
* 。。。

### 其实这个controller现在还是不好，包含的逻辑太多，我觉得从他依赖的数量上就能看出。

晚上看完一篇文章后尝试改了一下，大家有空可以讨论下，包括我自己也有不错的例子，可以现身说法~
@PYDebug  @limisky  @guoylyy  @myhelloos 