### PR TITLE
1. 审核列表支持过期和非过期的分割

### DIFF
--- a/app/scripts/controllers/app/Reservation.controller.js
+++ b/app/scripts/controllers/app/Reservation.controller.js
@@ -83,9 +83,10 @@
 		function viewReservation(reservation){
 			var dialog = ngDialog.open({
 				"template": "tpl/app/admin/modal/view-experiment-appointment.html",
-				"controller": "ViewExperimentAppointmentCtrl",
+				"controller": "ViewReservationController",
 				"closeByDocument": true,
 				"closeByEscape": true,
+				"className" : 'nm-dialog nm-dialog-md',
 				"resolve": {
 					data: function(){
 						return ReservationFactory.reservation().get({

--- a/app/scripts/controllers/app/Reservation.controller.js
+++ b/app/scripts/controllers/app/Reservation.controller.js
@@ -26,7 +26,11 @@
 		getReservationOutWeek()
 
 		function getReservationsInWeek(){
-			ReservationFactory.myReservationsInWeek().get()
+			ReservationFactory.myReservationsInWeek().get(
+				{
+					// isExpired: false //不过期的
+				}
+			)
 			.$promise
 			.then(function(response){
 				if(HttpResponseFactory.isResponseSuccess(response)){
@@ -43,6 +47,7 @@
 			ReservationFactory.myReservationsOutWeek().get({
 				pageNum: $scope.paginator.page,
 				pageSize: $scope.paginator.itemsPerPage,
+				// isExpired: false
 			})
 			.$promise
 			.then(function(response){

--- a/app/scripts/controllers/app/admin/ReservationManagement.controller.js
+++ b/app/scripts/controllers/app/admin/ReservationManagement.controller.js
@@ -9,10 +9,26 @@ function($scope, $stateParams, ReservationManageFactory, sessionService, general
 		status = 'APPLY';
 	}
 
+	$scope.verifyStatusList = [
+		{
+		code: false,
+		isActive: true,
+		value: "未过期的"
+		},
+		{
+		code: true,
+		isActive: false,
+		value: "已过期的"
+		}
+	]
+	$scope.selectCondition = $scope.verifyStatusList[0];
+
+
 	$scope.resources = angular.copy(ManagementService.DEFAULT_RESOURCE_TEMPLATE)
 	$scope.verifyResource = verifyResource
 	$scope.viewResource = viewResource
 	$scope.pageChanged = loadResources
+	$scope.filterConditionChange = filterConditionChange
 
 	loadResources()
 
@@ -26,7 +42,8 @@ function($scope, $stateParams, ReservationManageFactory, sessionService, general
 		return resourceFactory.page().get({
 			pageSize: $scope.resources.paginator.itemsPerPage,
 			pageNum: $scope.resources.paginator.page,
-			status: status
+			status: status,
+			isExpired: $scope.selectCondition.code
 		}).$promise
 	}
 
@@ -61,6 +78,11 @@ function($scope, $stateParams, ReservationManageFactory, sessionService, general
 		    AlertTool.close()
 		  }
 		})
+	}
+
+	function filterConditionChange(condition){
+		$scope.selectCondition = condition
+		loadResources()
 	}
 
 	function verifyResource(resource){

--- a/app/scripts/controllers/app/reservation.controller.js
+++ b/app/scripts/controllers/app/reservation.controller.js
@@ -83,9 +83,10 @@
 		function viewReservation(reservation){
 			var dialog = ngDialog.open({
 				"template": "tpl/app/admin/modal/view-experiment-appointment.html",
-				"controller": "ViewExperimentAppointmentCtrl",
+				"controller": "ViewReservationController",
 				"closeByDocument": true,
 				"closeByEscape": true,
+				"className" : 'nm-dialog nm-dialog-md',
 				"resolve": {
 					data: function(){
 						return ReservationFactory.reservation().get({

--- a/app/scripts/controllers/app/reservation.controller.js
+++ b/app/scripts/controllers/app/reservation.controller.js
@@ -26,7 +26,11 @@
 		getReservationOutWeek()
 
 		function getReservationsInWeek(){
-			ReservationFactory.myReservationsInWeek().get()
+			ReservationFactory.myReservationsInWeek().get(
+				{
+					// isExpired: false //不过期的
+				}
+			)
 			.$promise
 			.then(function(response){
 				if(HttpResponseFactory.isResponseSuccess(response)){
@@ -43,6 +47,7 @@
 			ReservationFactory.myReservationsOutWeek().get({
 				pageNum: $scope.paginator.page,
 				pageSize: $scope.paginator.itemsPerPage,
+				// isExpired: false
 			})
 			.$promise
 			.then(function(response){

--- a/app/scripts/controllers/app/teacher/TeacherAppointment.controller.js
+++ b/app/scripts/controllers/app/teacher/TeacherAppointment.controller.js
@@ -87,8 +87,9 @@
 		function viewReservation(reservation){
 			var dialog = ngDialog.open({
 				"template": "tpl/app/admin/modal/view-experiment-appointment.html",
-				"controller": "ViewExperimentAppointmentCtrl",
+				"controller": "ViewReservationController",
 				"closeByDocument": true,
+				"className" : 'nm-dialog nm-dialog-md',
 				"closeByEscape": true,
 				"resolve": {
 					data: function(){

--- a/app/tpl/app/admin/experiment-appointment.html
+++ b/app/tpl/app/admin/experiment-appointment.html
@@ -3,6 +3,15 @@
         <span>实验预约列表</span>
     </div>
     <div class = "wrapper-md">
+        <div class="p-b-md">
+          <uib-tabset class="nm-tab-btn-group">
+           <uib-tab ng-repeat="status in verifyStatusList" active="status.active" ng-click="filterConditionChange(status)">
+             <uib-tab-heading>
+               {{status.value}}
+             </uib-tab-heading>
+           </uib-tab>
+          </uib-tabset>
+        </div>
         <div class="panel panel-default">
             <table class = "table table-striped b-t b-light">
                 <thead>


### PR DESCRIPTION
审核列表支持过期和非过期的分割

##用法

主要实在查询预约的时候加入一个参数

isExpired: true/false/null

true: 只看过期的
false：只看不过期的
null：即不传，都看

```javascript
function getReservationsInWeek(){
			ReservationFactory.myReservationsInWeek().get(
				{
					// isExpired: false //不过期的
				}
			)
			.$promise
			.then(function(response){
				if(HttpResponseFactory.isResponseSuccess(response)){
					var data = HttpResponseFactory.getResponseData(response)
					angular.copy(data, $scope.reservationInWeekList)
				}else{
					errorHandler(response)
				}
			})
			.catch(errorHandler)
		}

```

